### PR TITLE
Fix http request body emptied by Verify

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/haisum/recaptcha"
+	"github.com/tech-angels/recaptcha"
 )
 
 func main() {

--- a/example/main.go
+++ b/example/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/haisum/recaptcha"
 	"log"
 	"net/http"
+
+	"github.com/haisum/recaptcha"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 		fmt.Fprintf(w, form)
 	})
 	http.HandleFunc("/submit", func(w http.ResponseWriter, r *http.Request) {
-		isValid := re.Verify(*r)
+		isValid := re.Verify(r)
 		if isValid {
 			fmt.Fprintf(w, "Valid")
 		} else {

--- a/recaptcha.go
+++ b/recaptcha.go
@@ -43,7 +43,7 @@ var postURL = "https://www.google.com/recaptcha/api/siteverify"
 // Verify method, verifies if current request have valid re-captcha response and returns true or false
 // This method also records any errors in validation.
 // These errors can be received by calling LastError() method.
-func (r *R) Verify(req http.Request) bool {
+func (r *R) Verify(req *http.Request) bool {
 	r.lastError = make([]string, 1)
 	response := req.FormValue("g-recaptcha-response")
 	client := &http.Client{Timeout: 20 * time.Second}

--- a/recaptcha.go
+++ b/recaptcha.go
@@ -2,7 +2,7 @@
 //
 // Installation
 //
-//   go get github.com/haisum/recaptcha
+//   go get github.com/tech-angels/recaptcha
 //
 // Usage
 //
@@ -11,7 +11,7 @@
 //
 // Source code
 //
-// Available on github: http://github.com/haisum/recaptcha
+// Available on github: http://github.com/tech-angels/recaptcha
 //
 // Author: Haisum (haisumbhatti@gmail.com)
 package recaptcha

--- a/recaptcha_test.go
+++ b/recaptcha_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/haisum/recaptcha"
+	"github.com/tech-angels/recaptcha"
 )
 
 func ExampleR_Verify() {

--- a/recaptcha_test.go
+++ b/recaptcha_test.go
@@ -2,9 +2,10 @@ package recaptcha
 
 import (
 	"fmt"
-	"github.com/haisum/recaptcha"
 	"log"
 	"net/http"
+
+	"github.com/haisum/recaptcha"
 )
 
 func ExampleR_Verify() {
@@ -31,7 +32,7 @@ func ExampleR_Verify() {
 		fmt.Fprintf(w, form)
 	})
 	http.HandleFunc("/submit", func(w http.ResponseWriter, r *http.Request) {
-		isValid := re.Verify(*r)
+		isValid := re.Verify(r)
 		if isValid {
 			fmt.Fprintf(w, "Valid")
 		} else {


### PR DESCRIPTION
Passing `http.Request` looks like a terrible idea. The body is a reader, and emptied for the copy.
That means if `re.Verify` is called _before_ any `r.FormValue("key")`, it will result in empty parameters.
This is an API breaking change, but necessary.

closes #6 
